### PR TITLE
Add required User-Agent header and update GitHub profile URL

### DIFF
--- a/config/profile.json
+++ b/config/profile.json
@@ -213,7 +213,7 @@
     "url": ""
   },
   "github": {
-    "url": "https://api.github.com/{endpoint}"
+    "url": "https://api.github.com/user"
   },
   "gitlab": {
     "url": "https://gitlab.com/api/v3/user"

--- a/lib/client.js
+++ b/lib/client.js
@@ -4,6 +4,7 @@ var request = require('request-compose').extend({
 }).client
 
 var profile = require('../config/profile')
+var pkg = require('../package')
 
 var before = {
   arcgis: () => ({qs: {f: 'json'}}),
@@ -36,14 +37,17 @@ var after = {
 }
 
 module.exports = (provider, data) => {
-  var options = {url: profile[provider.name].url}
+  var options = {
+    headers: { 'user-agent': `grant-profile ${pkg.version}` },
+    url: profile[provider.name].url
+  }
 
   if (provider.subdomain) {
     options.url = options.url.replace('[subdomain]', provider.subdomain)
   }
 
   if (provider.oauth === 2) {
-    options.headers = {authorization: `Bearer ${data.access_token}`}
+    options.headers.authorization = `Bearer ${data.access_token}`
   }
   else if (provider.oauth === 1) {
     options.oauth = {


### PR DESCRIPTION
At least GitHub requires a `User-Agent` header to be present when making profile requests (otherwise it will send a 403 error). It probably makes sense to always add it.

This PR also fixes the GitHub user profile URL.