### PR TITLE
Fix Salesforce URL

### DIFF
--- a/config/profile.json
+++ b/config/profile.json
@@ -393,7 +393,7 @@
     "profile_url": "https://api.runkeeper.com/user"
   },
   "salesforce": {
-    "profile_url": "https://[subdomain].salesforce.com/profile.get"
+    "profile_url": "https://login.salesforce.com/services/oauth2/userinfo"
   },
   "shoeboxed": {
     "profile_url": "https://api.shoeboxed.com/v2/user"

--- a/lib/client.js
+++ b/lib/client.js
@@ -30,6 +30,7 @@ var before = {
   vk: (data) => ({qs: {access_token: data.access_token}}),
   weibo: (data) => ({qs: {access_token: data.access_token}}),
   twitter: (data) => ({qs: {user_id: data.raw.user_id}}),
+  salesforce: (data) => ({url: data.raw.id}),
 }
 
 var after = {

--- a/lib/client.js
+++ b/lib/client.js
@@ -30,7 +30,6 @@ var before = {
   vk: (data) => ({qs: {access_token: data.access_token}}),
   weibo: (data) => ({qs: {access_token: data.access_token}}),
   twitter: (data) => ({qs: {user_id: data.raw.user_id}}),
-  salesforce: (data) => ({url: data.raw.id}),
 }
 
 var after = {


### PR DESCRIPTION
Set the URL to the value of `id` in the response.

`https://[subdomain].salesforce.com/profile.get` returns a 404. This PR fixes that by replacing the entire URL with the value of the `id` field in the response to a token request.