### PR TITLE
Update Vk to support required version param

### DIFF
--- a/config/profile.json
+++ b/config/profile.json
@@ -532,7 +532,7 @@
     "profile_url": ""
   },
   "vk": {
-    "profile_url": "https://api.vk.com/method/users.get"
+    "profile_url": "https://api.vk.com/method/users.get?v=5.103"
   },
   "wechat": {
     "profile_url": ""


### PR DESCRIPTION
This seems to be required now in order to make requests to their API methods. I took the latest version number `"5.103` from https://vk.com/dev/versions and it works now.

```
{"error":{"error_code":8,"error_msg":"Invalid request: v is required. Version param should be passed as \"v\". \"version\" param is invalid and not supported.","request_params":[{"key":"method","value":"users.get"},{"key":"oauth","value":"1"}]}}
```